### PR TITLE
fix github link :3

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -292,7 +292,7 @@
             <p class="pb-5">
               So you think you have the guts to cook a potato or two by yourself? Great! POSP is entirely open source, so head out to our
               <a
-                href="https://t.me/SaucyPotatoesOfficial"
+                href="https://github.com/PotatoProject"
                 class="font-semibold text-p-yellow"
                 target="_blank"
               >GitHub page</a> for instructions and get right to it!


### PR DESCRIPTION
When you click on 'Github' it's supposed to take you to https://github.com/PotatoProject and not https://t.me/SaucyPotatoesOfficial
It works on mobile because of[ this ](https://github.com/ZerNico/potatohub/blob/6d713ba2c9147118cff18af051e81c7cb143f1af/components/dev-dev-card-mobile.vue#L17)